### PR TITLE
Fixing bug with stopHidden option.

### DIFF
--- a/src/jquery.slotmachine.js
+++ b/src/jquery.slotmachine.js
@@ -422,7 +422,7 @@
 		*/
 		function _isVisible(){
 			if(self.settings.stopHidden === false){
-				return false;
+				return true;
 			}
 			//Stop animation if element is [above||below] screen, best for performance
 			var above = $slot.offset().top > $(window).scrollTop() + $(window).height(),


### PR DESCRIPTION
The logic around the 'stopHidden' option was reversed — if stopHidden is false, we don't want it to stop when it's hidden, thus _isVisible() should return true even though it's not, since we want the animation to continue. It's a bit confusing semantically, which could be improved by changing some function names...
