### PR TITLE
add .js to main

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,8 +22,8 @@
     "type": "git",
     "url": "git://github.com/josex2r/jQuery-SlotMachine.git"
   },
-  "main": "./dist/jquery.slotmachine.min",
-   "bugs": "https://github.com/josex2r/jQuery-SlotMachine/issues",
+  "main": "./dist/jquery.slotmachine.min.js",
+  "bugs": "https://github.com/josex2r/jQuery-SlotMachine/issues",
   "licenses": [
     {
       "type": "MIT",


### PR DESCRIPTION
If `"main": "./dist/jquery.slotmachine.min.js"` doesn't have `.js` on the end, then [bower-main] (https://github.com/frodefi/bower-main) can't use it automagically.